### PR TITLE
Avoid printing unnecessary jump labels

### DIFF
--- a/porth.py
+++ b/porth.py
@@ -459,6 +459,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 out.write("    ;; -- end --\n")
                 if ip + 1 != op.jmp:
                     out.write("    jmp addr_%d\n" % op.jmp)
+                out.write("addr_%d:\n" % (ip + 1))
             elif op.typ == OpType.DUP:
                 out.write("    ;; -- dup -- \n")
                 out.write("    pop rax\n")

--- a/porth.py
+++ b/porth.py
@@ -328,7 +328,6 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
         for ip in range(len(program)):
             op = program[ip]
             assert len(OpType) == 36, "Exhaustive ops handling in generate_nasm_linux_x86_64"
-            out.write("addr_%d:\n" % ip)
             if op.typ == OpType.PUSH_INT:
                 assert op.value is not None, "This could be a bug in the compilation step"
                 out.write("    ;; -- push int %d --\n" % op.value)
@@ -452,8 +451,11 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 out.write("    ;; -- else --\n")
                 assert op.jmp is not None, "This could be a bug in the compilation step"
                 out.write("    jmp addr_%d\n" % op.jmp)
+                # on `0` the `if` instruction jumps to the one that follows `else`.
+                out.write("addr_%d:\n" % (ip + 1)) 
             elif op.typ == OpType.END:
                 assert op.jmp is not None, "This could be a bug in the compilation step"
+                out.write("addr_%d:\n" % ip)
                 out.write("    ;; -- end --\n")
                 if ip + 1 != op.jmp:
                     out.write("    jmp addr_%d\n" % op.jmp)
@@ -488,6 +490,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 out.write("    push rbx\n")
             elif op.typ == OpType.WHILE:
                 out.write("    ;; -- while --\n")
+                out.write("addr_%d:\n" % ip)
             elif op.typ == OpType.DO:
                 out.write("    ;; -- do --\n")
                 out.write("    pop rax\n")


### PR DESCRIPTION
By printing the labels only when necessary the generated assembly is a bit prettier.