### PR TITLE
Unhardcode 2dup operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Porth is planned to be
 Hello, World:
 
 ```pascal
-include "io.porth"
+include "std.porth"
 
 "Hello, World\n" write
 ```
@@ -123,11 +123,11 @@ Those, a single string pushes two values onto the data stack: the size and the p
 Example:
 
 ```
-include "io.porth"
+include "std.porth"
 "Hello, World" write
 ```
 
-The `write` macro from `io.porth` module expects two values on the data stack: the size of the buffer it needs to print to stdout and the pointer to the beginning of the buffer. Both of the values are provided by the string `"Hello, World"`.
+The `write` macro from `std.porth` module expects two values on the data stack: the size of the buffer it needs to print to stdout and the pointer to the beginning of the buffer. Both of the values are provided by the string `"Hello, World"`.
 
 #### Character
 

--- a/examples/hello-world.porth
+++ b/examples/hello-world.porth
@@ -1,3 +1,3 @@
-include "io.porth"
+include "std.porth"
 
 "Hello, World\n" write

--- a/examples/rule110.porth
+++ b/examples/rule110.porth
@@ -2,7 +2,7 @@
 // ^
 // mem
 
-include "io.porth"
+include "std.porth"
 
 macro N 100 end
 

--- a/examples/seq100.porth
+++ b/examples/seq100.porth
@@ -1,3 +1,5 @@
+include "std.porth"
+
 100 0 while 2dup > do
     dup print 1 +
 end

--- a/porth.py
+++ b/porth.py
@@ -41,7 +41,6 @@ class OpType(Enum):
     INCLUDE=auto()
 
     DUP=auto()
-    DUP2=auto()
     SWAP=auto()
     DROP=auto()
     OVER=auto()
@@ -96,7 +95,7 @@ def simulate_little_endian_linux(program: Program):
     str_size = 0
     ip = 0
     while ip < len(program):
-        assert len(OpType) == 39, "Exhaustive op handling in simulate_little_endian_linux"
+        assert len(OpType) == 38, "Exhaustive op handling in simulate_little_endian_linux"
         op = program[ip]
         if op.typ == OpType.PUSH_INT:
             assert isinstance(op.value, int), "This could be a bug in the compilation step"
@@ -209,14 +208,6 @@ def simulate_little_endian_linux(program: Program):
             a = stack.pop()
             stack.append(a)
             stack.append(a)
-            ip += 1
-        elif op.typ == OpType.DUP2:
-            b = stack.pop()
-            a = stack.pop()
-            stack.append(a)
-            stack.append(b)
-            stack.append(a)
-            stack.append(b)
             ip += 1
         elif op.typ == OpType.SWAP:
             a = stack.pop()
@@ -341,7 +332,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
         out.write("_start:\n")
         for ip in range(len(program)):
             op = program[ip]
-            assert len(OpType) == 39, "Exhaustive ops handling in generate_nasm_linux_x86_64"
+            assert len(OpType) == 38, "Exhaustive ops handling in generate_nasm_linux_x86_64"
             out.write("addr_%d:\n" % ip)
             if op.typ == OpType.PUSH_INT:
                 assert isinstance(op.value, int), "This could be a bug in the compilation step"
@@ -488,14 +479,6 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 out.write("    pop rax\n")
                 out.write("    push rax\n")
                 out.write("    push rax\n")
-            elif op.typ == OpType.DUP2:
-                out.write("    ;; -- 2dup -- \n")
-                out.write("    pop rbx\n")
-                out.write("    pop rax\n")
-                out.write("    push rax\n")
-                out.write("    push rbx\n")
-                out.write("    push rax\n")
-                out.write("    push rbx\n")
             elif op.typ == OpType.SWAP:
                 out.write("    ;; -- swap --\n")
                 out.write("    pop rax\n")
@@ -603,7 +586,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
         out.write("segment .bss\n")
         out.write("mem: resb %d\n" % MEM_CAPACITY)
 
-assert len(OpType) == 39, "Exhaustive BUILTIN_WORDS definition. Keep in mind that not all of the new ops need to be defined in here. Only those that introduce new builtin words."
+assert len(OpType) == 38, "Exhaustive BUILTIN_WORDS definition. Keep in mind that not all of the new ops need to be defined in here. Only those that introduce new builtin words."
 BUILTIN_WORDS = {
     '+': OpType.PLUS,
     '-': OpType.MINUS,
@@ -630,7 +613,6 @@ BUILTIN_WORDS = {
     'include': OpType.INCLUDE,
 
     'dup': OpType.DUP,
-    '2dup': OpType.DUP2,
     'swap': OpType.SWAP,
     'drop': OpType.DROP,
     'over': OpType.OVER,
@@ -696,7 +678,7 @@ def compile_tokens_to_program(tokens: List[Token], include_paths: List[str]) -> 
         else:
             assert False, 'unreachable'
 
-        assert len(OpType) == 39, "Exhaustive ops handling in compile_tokens_to_program. Keep in mind that not all of the ops need to be handled in here. Only those that form blocks."
+        assert len(OpType) == 38, "Exhaustive ops handling in compile_tokens_to_program. Keep in mind that not all of the ops need to be handled in here. Only those that form blocks."
         if op.typ == OpType.IF:
             program.append(op)
             stack.append(ip)

--- a/std/io.porth
+++ b/std/io.porth
@@ -1,4 +1,0 @@
-include "linux.porth"
-
-/// Writes a string into the standard output
-macro write STDOUT SYS_write syscall3 end

--- a/std/std.porth
+++ b/std/std.porth
@@ -1,3 +1,4 @@
+/// Standard streams
 macro STDIN  0 end
 macro STDOUT 1 end
 macro STDERR 2 end
@@ -319,3 +320,8 @@ macro SYS_process_vm_readv 310 end
 macro SYS_process_vm_writev 311 end
 macro SYS_kcmp 312 end
 macro SYS_finit_module 313 end
+
+/// Writes a string into the standard output
+macro write STDOUT SYS_write syscall3 end
+
+macro 2dup over over end

--- a/tests/arithmetics.porth
+++ b/tests/arithmetics.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // Add
 34 35 + print

--- a/tests/bitwise.porth
+++ b/tests/bitwise.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // shift left
 1  3 shl print

--- a/tests/comparison.porth
+++ b/tests/comparison.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // Equals
 69 420  = print

--- a/tests/control-flow.porth
+++ b/tests/control-flow.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // if-else
 34 35 + 70 = if 69 print else 420 print end

--- a/tests/memory.porth
+++ b/tests/memory.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // write "abc" into the memory
 mem 0 + 97 .

--- a/tests/stack.porth
+++ b/tests/stack.porth
@@ -1,4 +1,4 @@
-include "io.porth"
+include "std.porth"
 
 // push int
 10 20 30 print print print


### PR DESCRIPTION
Remove it from the core of the language and implement it as part of
the standard library.