### PR TITLE
Remove redundant 8 shr in store64

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
-Copyright 2021 Alexey Kutepov <reximkut@gmail.com>
+MIT License
+
+Copyright (C) 2021 Alexey Kutepov <reximkut@gmail.com>
+and the Porth contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/std/std.porth
+++ b/std/std.porth
@@ -356,7 +356,7 @@ macro store64
   2dup 255 band . 8 shr swap 1 + swap
   2dup 255 band . 8 shr swap 1 + swap
   2dup 255 band . 8 shr swap 1 + swap
-  2dup 255 band . 8 shr 2drop
+  2dup 255 band . 2drop
 end
 
 macro inc64


### PR DESCRIPTION
The `8 shr` in the last line of `store64` is redundant because the integer will get wiped anyway.

Also update the copyright notice in LICENSE. I know that this contribution is trivial, but there seem to be other contributors as well.