### PR TITLE
32bit load and store intrinsics

### DIFF
--- a/porth.py
+++ b/porth.py
@@ -50,6 +50,8 @@ class Intrinsic(Enum):
     MEM=auto()
     LOAD=auto()
     STORE=auto()
+    LOAD32=auto()
+    STORE32=auto()
     LOAD64=auto()
     STORE64=auto()
     ARGC=auto()
@@ -181,7 +183,7 @@ def simulate_little_endian_linux(program: Program, argv: List[str]):
             else:
                 ip += 1
         elif op.typ == OpType.INTRINSIC:
-            assert len(Intrinsic) == 33, "Exhaustive handling of intrinsic in simulate_little_endian_linux()"
+            assert len(Intrinsic) == 35, "Exhaustive handling of intrinsic in simulate_little_endian_linux()"
             if op.operand == Intrinsic.PLUS:
                 a = stack.pop()
                 b = stack.pop()
@@ -291,6 +293,19 @@ def simulate_little_endian_linux(program: Program, argv: List[str]):
                 store_value = stack.pop()
                 store_addr = stack.pop()
                 mem[store_addr] = store_value & 0xFF
+                ip += 1
+            elif op.operand == Intrinsic.LOAD32:
+                addr = stack.pop()
+                _bytes = bytearray(4)
+                for offset in range(0,4):
+                    _bytes[offset] = mem[addr + offset]
+                stack.append(int.from_bytes(_bytes, byteorder="little"))
+                ip += 1
+            elif op.operand == Intrinsic.STORE32:
+                store_value32 = stack.pop().to_bytes(length=8, byteorder="little")
+                store_addr32 = stack.pop()
+                for index in range(0, 4):
+                    mem[store_addr32 + index] = store_value32[index]
                 ip += 1
             elif op.operand == Intrinsic.LOAD64:
                 addr = stack.pop()
@@ -624,7 +639,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 assert isinstance(op.operand, int), "This could be a bug in the compilation step"
                 out.write("    jz addr_%d\n" % op.operand)
             elif op.typ == OpType.INTRINSIC:
-                assert len(Intrinsic) == 33, "Exhaustive intrinsic handling in generate_nasm_linux_x86_64()"
+                assert len(Intrinsic) == 35, "Exhaustive intrinsic handling in generate_nasm_linux_x86_64()"
                 if op.operand == Intrinsic.PLUS:
                     out.write("    ;; -- plus --\n")
                     out.write("    pop rax\n")
@@ -778,6 +793,17 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                     out.write("    mov rax, [args_ptr]\n")
                     out.write("    add rax, 8\n")
                     out.write("    push rax\n")
+                elif op.operand == Intrinsic.LOAD32:
+                    out.write("    ;; -- load --\n")
+                    out.write("    pop rax\n")
+                    out.write("    xor rbx, rbx\n")
+                    out.write("    mov ebx, [rax]\n")
+                    out.write("    push rbx\n")
+                elif op.operand == Intrinsic.STORE32:
+                    out.write("    ;; -- store --\n")
+                    out.write("    pop rbx\n");
+                    out.write("    pop rax\n");
+                    out.write("    mov [rax], ebx\n");
                 elif op.operand == Intrinsic.LOAD64:
                     out.write("    ;; -- load --\n")
                     out.write("    pop rax\n")
@@ -872,7 +898,7 @@ KEYWORD_NAMES = {
     'include': Keyword.INCLUDE,
 }
 
-assert len(Intrinsic) == 33, "Exhaustive INTRINSIC_NAMES definition"
+assert len(Intrinsic) == 35, "Exhaustive INTRINSIC_NAMES definition"
 INTRINSIC_NAMES = {
     '+': Intrinsic.PLUS,
     '-': Intrinsic.MINUS,
@@ -896,6 +922,8 @@ INTRINSIC_NAMES = {
     'mem': Intrinsic.MEM,
     '.': Intrinsic.STORE,
     ',': Intrinsic.LOAD,
+    '.32': Intrinsic.STORE32,
+    ',32': Intrinsic.LOAD32,
     '.64': Intrinsic.STORE64,
     ',64': Intrinsic.LOAD64,
     'argc': Intrinsic.ARGC,


### PR DESCRIPTION
Added 32bit load and store intrinsics with the same scheema as the 64 and 8-bit versions.
The intrinsics work both in simulation and if they are compiled.

The functions were tested by the following program:

```
include "std.porth"

//prints 0
mem 0 .32
mem ,32 print

//prints 255
mem 255 .32
mem ,32 print

//prints 256
mem 256 .32
mem ,32 print

//prints 65535
mem 65535 .32
mem ,32 print

//prints 65536
mem 65536 .32
mem ,32 print

//prints 4294967295
mem 4294967295 .32
mem ,32 print

//prints 0
mem 4294967296 .32
mem ,32 print
```