### PR TITLE
Implement Casting Intrinsics for casting types during the type checking stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,24 @@ byte = load(word)
 push(byte)
 ```
 
+#### Type Casting
+
+- `(int)` - cast a non-integer value to an integer during the type checking stage. Has no effect on simulation or compiled programs.
+```
+value = pop()
+push(int(value))
+```
+- `(bool)` - cast a non-boolean value to a boolean during the type checking stage. Has no effect on simulation or compiled programs.
+```
+value = pop()
+push(bool(value))
+```
+- `(ptr)` - cast a non-pointer value to a pointer during the type checking stage. Has no effect on simulation or compiled programs.
+```
+value = pop()
+push(ptr(value))
+```
+
 #### System
 
 - `syscall<n>` - perform a syscall with n arguments where n is in range `[0..6]`. (`syscall1`, `syscall2`, etc)

--- a/porth.py
+++ b/porth.py
@@ -1153,7 +1153,7 @@ INTRINSIC_BY_NAMES = {
     'syscall3': Intrinsic.SYSCALL3,
     'syscall4': Intrinsic.SYSCALL4,
     'syscall5': Intrinsic.SYSCALL5,
-    'syscall6': Intrinsic.SYSCALL5,
+    'syscall6': Intrinsic.SYSCALL6,
     '(int)': Intrinsic.CASTINT,
     '(bool)': Intrinsic.CASTBOOL,
     '(ptr)': Intrinsic.CASTPTR,

--- a/porth.py
+++ b/porth.py
@@ -61,6 +61,9 @@ class Intrinsic(Enum):
     SYSCALL4=auto()
     SYSCALL5=auto()
     SYSCALL6=auto()
+    CASTINT=auto()
+    CASTBOOL=auto()
+    CASTPTR=auto()
 
 class OpType(Enum):
     PUSH_INT=auto()
@@ -181,7 +184,7 @@ def simulate_little_endian_linux(program: Program, argv: List[str]):
             else:
                 ip += 1
         elif op.typ == OpType.INTRINSIC:
-            assert len(Intrinsic) == 33, "Exhaustive handling of intrinsic in simulate_little_endian_linux()"
+            assert len(Intrinsic) == 36, "Exhaustive handling of intrinsic in simulate_little_endian_linux()"
             if op.operand == Intrinsic.PLUS:
                 a = stack.pop()
                 b = stack.pop()
@@ -360,6 +363,15 @@ def simulate_little_endian_linux(program: Program, argv: List[str]):
                 assert False, "not implemented"
             elif op.operand == Intrinsic.SYSCALL6:
                 assert False, "not implemented"
+            elif op.operand == Intrinsic.CASTINT:
+                # Do nothing, Intrinsic.CASTINT is only used during the type checking phase to cast types.
+                ip += 1
+            elif op.operand == Intrinsic.CASTBOOL:
+                # Do nothing, Intrinsic.CASTBOOL is only used during the type checking phase to cast types.
+                ip += 1
+            elif op.operand == Intrinsic.CASTPTR:
+                # Do nothing, Intrinsic.CASTPTR is only used during the type checking phase to cast types.
+                ip += 1
             else:
                 assert False, "unreachable"
         else:
@@ -388,7 +400,7 @@ def type_check_program(program: Program):
             stack.append((DataType.INT, op.loc))
             stack.append((DataType.PTR, op.loc))
         elif op.typ == OpType.INTRINSIC:
-            assert len(Intrinsic) == 33, "Exhaustive intrinsic handling in type_check_program()"
+            assert len(Intrinsic) == 36, "Exhaustive intrinsic handling in type_check_program()"
             assert isinstance(op.operand, Intrinsic), "This could be a bug in compilation step"
             if op.operand == Intrinsic.PLUS:
                 assert len(DataType) == 3, "Exhaustive type handling in PLUS intrinsic"
@@ -728,6 +740,24 @@ def type_check_program(program: Program):
                 for i in range(7):
                     stack.pop()
                 stack.append((DataType.INT, op.loc))
+            elif op.operand == Intrinsic.CASTINT:
+                if len(stack) < 1:
+                    not_enough_arguments_for_intrinsic(op.operand, op.loc)
+                    exit(1)
+                stack.pop()
+                stack.append((DataType.INT, op.loc))
+            elif op.operand == Intrinsic.CASTBOOL:
+                if len(stack) < 1:
+                    not_enough_arguments_for_intrinsic(op.operand, op.loc)
+                    exit(1)
+                stack.pop()
+                stack.append((DataType.BOOL, op.loc))
+            elif op.operand == Intrinsic.CASTPTR:
+                if len(stack) < 1:
+                    not_enough_arguments_for_intrinsic(op.operand, op.loc)
+                    exit(1)
+                stack.pop()
+                stack.append((DataType.PTR, op.loc))
             else:
                 assert False, "unreachable"
         elif op.typ == OpType.IF:
@@ -829,7 +859,7 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                 assert isinstance(op.operand, int), "This could be a bug in the compilation step"
                 out.write("    jz addr_%d\n" % op.operand)
             elif op.typ == OpType.INTRINSIC:
-                assert len(Intrinsic) == 33, "Exhaustive intrinsic handling in generate_nasm_linux_x86_64()"
+                assert len(Intrinsic) == 36, "Exhaustive intrinsic handling in generate_nasm_linux_x86_64()"
                 if op.operand == Intrinsic.PLUS:
                     out.write("    ;; -- plus --\n")
                     out.write("    pop rax\n")
@@ -1050,6 +1080,18 @@ def generate_nasm_linux_x86_64(program: Program, out_file_path: str):
                     out.write("    pop r9\n")
                     out.write("    syscall\n")
                     out.write("    push rax\n")
+                elif op.operand == Intrinsic.CASTINT:
+                    # Do nothing, Intrinsic.CASTINT is only used during the type checking phase to cast types.
+                    out.write("    ;; -- cast int --\n")
+                    pass
+                elif op.operand == Intrinsic.CASTBOOL:
+                    # Do nothing, Intrinsic.CASTBOOL is only used during the type checking phase to cast types.
+                    out.write("    ;; -- cast bool --\n")
+                    pass
+                elif op.operand == Intrinsic.CASTPTR:
+                    # Do nothing, Intrinsic.CASTPTR is only used during the type checking phase to cast types.
+                    out.write("    ;; -- cast ptr --\n")
+                    pass
                 else:
                     assert False, "unreachable"
             else:
@@ -1077,7 +1119,7 @@ KEYWORD_NAMES = {
     'include': Keyword.INCLUDE,
 }
 
-assert len(Intrinsic) == 33, "Exhaustive INTRINSIC_BY_NAMES definition"
+assert len(Intrinsic) == 36, "Exhaustive INTRINSIC_BY_NAMES definition"
 INTRINSIC_BY_NAMES = {
     '+': Intrinsic.PLUS,
     '-': Intrinsic.MINUS,
@@ -1111,7 +1153,9 @@ INTRINSIC_BY_NAMES = {
     'syscall3': Intrinsic.SYSCALL3,
     'syscall4': Intrinsic.SYSCALL4,
     'syscall5': Intrinsic.SYSCALL5,
-    'syscall6': Intrinsic.SYSCALL6,
+    '(int)': Intrinsic.CASTINT,
+    '(bool)': Intrinsic.CASTBOOL,
+    '(ptr)': Intrinsic.CASTPTR,
 }
 INTRINSIC_NAMES = {v: k for k, v in INTRINSIC_BY_NAMES.items()}
 

--- a/porth.py
+++ b/porth.py
@@ -1153,6 +1153,7 @@ INTRINSIC_BY_NAMES = {
     'syscall3': Intrinsic.SYSCALL3,
     'syscall4': Intrinsic.SYSCALL4,
     'syscall5': Intrinsic.SYSCALL5,
+    'syscall6': Intrinsic.SYSCALL5,
     '(int)': Intrinsic.CASTINT,
     '(bool)': Intrinsic.CASTBOOL,
     '(ptr)': Intrinsic.CASTPTR,

--- a/std/std.porth
+++ b/std/std.porth
@@ -344,3 +344,11 @@ macro strlen
   while dup , 0 != do 1 + end
   swap -
 end
+
+macro true
+  1 (bool)
+end
+
+macro false
+  0 (bool)
+end


### PR DESCRIPTION
Currently, there is no way to cast types during the type checking step. If you want to interpret an `int` as a `bool` or a `ptr`, you're out of luck. This PR implements three new Intrinsics, `Intrinsic.CASTINT`, `Intrinsic.CASTBOOL`, and `Intrinsic.CASTPTR`, which cast the top element of the stack to the specified type. These Intrinsics do nothing during the simulation process or when compiled, they are purely used during the type-checking step. The words for these Intrinsics are `(int)`, `(bool)`, and `(ptr)` (inspired by many of the C-style languages).

Example usage:
```
include "std.porth"

// Push the integer 1 (type = int) onto the stack. Then, cast the integer into a boolean. The type checker will no longer error when trying to use the value as a condition.
1 (bool)
// Use the value as a condition
if
  "No error!" stdout write drop
end
```

Additionally, this PR adds two new macros in `std.porth`: `true` and `false`, which are shorthand for `1 (bool)` and `0 (bool)` respectively.