### PR TITLE
Native print

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pop()
 a = pop()
 print(a)
 ```
-- `over`
+- `over` - copy the second item on the stack to the top
 ```
 a = pop()
 b = pop()

--- a/examples/native-print.porth
+++ b/examples/native-print.porth
@@ -13,8 +13,6 @@ include "std.porth"
 //   - a scratch buffer like this might make sense as a peer to mem, str, argv
 //   - alternatively, being able to allocate this temp buffer on the stack seems
 //     like it would be useful in avoiding contention for a global buffer
-// - uses `rot` which is a basic stack word from ANS forth
-//   - without it, it was not convenient to use the third item on the stack
 
 // --------------------------------------------------------------------------------
 // possibly generally useful function, maybe a std.porth candidate
@@ -94,12 +92,8 @@ end
 
 -350 signmag print print
 
-"stack ends up empty check\n"
-
 0 print1
 
 123 print1
 
 -123 print1
-
-stdout write

--- a/examples/native-print.porth
+++ b/examples/native-print.porth
@@ -1,0 +1,105 @@
+include "std.porth"
+
+// print1 - prints an integer
+//
+// - improves on the built-in print by handling negative integers in compiled
+//   code "properly" -- with a leading minus sign the same as in the simulator.
+// - currently expands inline due to macros being the only code abstraction
+//   we have
+// - perhaps useful as a basis of a native print written in porth at some point
+//   - the built-in print is derived from compiling a similar conversion in C
+// - uses a temporary area within mem (32 bytes) to accumulate the characters
+//   of the output string from back to front.
+//   - a scratch buffer like this might make sense as a peer to mem, str, argv
+//   - alternatively, being able to allocate this temp buffer on the stack seems
+//     like it would be useful in avoiding contention for a global buffer
+// - uses `rot` which is a basic stack word from ANS forth
+//   - without it, it was not convenient to use the third item on the stack
+
+// --------------------------------------------------------------------------------
+// possibly generally useful function, maybe a std.porth candidate
+
+// (num:int -- neg?:bool mag:int)
+// converts num to sign-magnitude form
+macro signmag
+  dup 0 <
+  dup if
+    swap 0 swap - swap
+  end
+  swap
+end
+
+// --------------------------------------------------------------------------------
+// temporary buffer
+
+macro printbuf-start
+  mem 10000 +
+end
+
+macro printbuf-end
+  printbuf-start 31 +
+end
+
+// --------------------------------------------------------------------------------
+// helpers for the main print1 word
+
+// (ptr:addr mag:int -- ptr(-1):addr mag(/10):int)
+// stores the character code for the least significant
+// decimal digit of non-negative mag to ptr,
+// decrements ptr, divs mag by 10.
+
+macro buffer-digit!
+  10 divmod               // ptr div mod
+  rot dup                 // div mod ptr ptr
+  rot                     // div ptr ptr mod
+  '0' + . 1 -             // div ptr(-1)
+  swap                    // ptr div
+end
+
+// (ptr:addr mag:int -- ptr(-n):addr)
+// stores the character codes for the decimal digits
+// of mag in reverse order starting at ptr. decrements
+// ptr by the number of characters stored.
+macro buffer-mag!
+  buffer-digit!           // ptr(-1) mag(/10)
+  while dup 0 > do
+    buffer-digit!         // ptr(-1) mag(/10)
+  end                     // ptr 0
+  drop                    // ptr
+end
+
+// --------------------------------------------------------------------------------
+// (int --)
+// prints an int to stdout followed by a newline
+// overwrites printbuf, accumulating characters backward from its end
+macro print1
+  signmag printbuf-end    // neg? mag ptr
+
+  dup '\n' . 1 -          // neg? mag ptr(-1)
+  swap buffer-mag!        // neg? ptr
+  swap                    // ptr neg?
+  if                      // ptr
+    dup '-' . 1 -         // ptr(-1)
+  end
+
+  dup printbuf-end swap - // ptr len
+  swap 1 +                // len ptr(+1)
+  stdout write drop
+end
+
+// --------------------------------------------------------------------------------
+// tests
+
+350 signmag print print
+
+-350 signmag print print
+
+"stack ends up empty check\n"
+
+0 print1
+
+123 print1
+
+-123 print1
+
+stdout write

--- a/examples/native-print.txt
+++ b/examples/native-print.txt
@@ -1,0 +1,16 @@
+:i argc 0
+:b stdin 0
+
+:i returncode 0
+:b stdout 49
+350
+0
+350
+1
+0
+123
+-123
+stack ends up empty check
+
+:b stderr 0
+

--- a/examples/native-print.txt
+++ b/examples/native-print.txt
@@ -2,7 +2,7 @@
 :b stdin 0
 
 :i returncode 0
-:b stdout 49
+:b stdout 23
 350
 0
 350
@@ -10,7 +10,6 @@
 0
 123
 -123
-stack ends up empty check
 
 :b stderr 0
 


### PR DESCRIPTION
- `print1` - an example with native code to print an integer via `write` to `stdout`
  - equivalent to the built-in print, but written in porth
  - with the advantage of printing negative integers with a leading minus when compiled just like when simulated

- includes an additional stack word `rot` because without it, using the 3rd item on the stack is inconvenient

- implemented as an example because perhaps we don't want to expand print inline on every use.
  - maybe porth will support a callable procedure abstraction at some point

- includes signmag that converts an integer to sign-magnitude form
  - possibly useful for std.porth at some point