### PR TITLE
Add a cast(int)

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,6 @@
 arithmetics
 bitwise
+cast-int
 comparison
 memory
 stack

--- a/tests/cast-int.porth
+++ b/tests/cast-int.porth
@@ -1,0 +1,1 @@
+10 cast(ptr) cast(int) 4 5 < cast(int) + print

--- a/tests/cast-int.txt
+++ b/tests/cast-int.txt
@@ -1,0 +1,9 @@
+:i argc 0
+:b stdin 0
+
+:i returncode 0
+:b stdout 3
+11
+
+:b stderr 0
+


### PR DESCRIPTION
If a PTR just make an INT out of it, if a BOOL make a 1 if true, 0 if false.

I need it because writing an LLVM implementation (which is nearly finished already but I don't think it will ever be merged, just fun to do) I need a zero extension to get ints from bools and a cast from bool to int seems the perfect place to zero extend.
Plus that just makes sense so ...