### PR TITLE
Stack pointer operation (enables putting putd in `std.porth`)

### DIFF
--- a/std/std.porth
+++ b/std/std.porth
@@ -387,6 +387,35 @@ macro puts
   stdout write drop
 end
 
+macro putd 
+// a 32-byte buffer on the stack
+
+0 swap // a pretty awkward way to bubble up the value
+0 swap 
+0 swap
+0 swap
+
+  dup 0 = if
+    "0" puts
+  else
+    ref 8 + 32 +
+    while over 0 > do
+      1 - dup rot
+      10 divmod
+      rot swap '0' + . swap
+    end
+    dup
+    ref 24 + 32 + swap - swap puts
+  end
+  drop
+
+// free the buffer
+drop 
+drop 
+drop 
+drop
+end
+
 macro eputs
   stderr write drop
 end


### PR DESCRIPTION
A simple operation that pushes a pointer to the element that is currenlty on the top of the stack.

With this functionality it's possible to allocate a temporary buffer on the stack by repeatedly pushing 0, and this enables to implement putd without a static buffer in memory, so putd can now be in the standard library.

As a sidenote, building `gol.porth` will now fail due to the macro name collision.

There is one drawback, and that is that this will create a discrepancy between simulation and compilation, as there is no easy way to implement this in python I think.
Assuming that the stack is contiguoous in memory in the bootstrapped version, there should really be no problem after that.

